### PR TITLE
feat: ajouter import de documents

### DIFF
--- a/ia_provider/exporter.py
+++ b/ia_provider/exporter.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import io
 import json
 from dataclasses import asdict, is_dataclass
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import markdown as md
 from bs4 import BeautifulSoup
@@ -201,14 +201,23 @@ class MarkdownToDocxConverter:
 
             self.doc.add_paragraph(text)
 
-def generer_export_docx(resultats: List[Any], styles: Dict[str, Dict[str, Any]]) -> io.BytesIO:
+def generer_export_docx(
+    resultats: List[Any],
+    styles_interface: Dict[str, Dict[str, Any]],
+    template_source: Optional[Dict[str, Any]] = None,
+) -> io.BytesIO:
     """Génère un document DOCX à partir d'une liste de résultats de batch.
+
+    ``styles_interface`` correspond aux styles définis dans l'interface.
+    ``template_source`` peut contenir des styles extraits d'un document importé
+    et est prioritaire sur ``styles_interface`` lorsqu'il est fourni.
 
     Chaque résultat doit contenir au minimum les champs ``status``,
     ``prompt_text`` et ``clean_response`` (ou ``response``).
     """
 
     document = Document()
+    styles = template_source if template_source is not None else styles_interface
     converter = MarkdownToDocxConverter(document, styles)
 
     succeeded: List[Dict[str, Any]] = []

--- a/ia_provider/importer.py
+++ b/ia_provider/importer.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+"""Module d'analyse de documents pour l'import."""
+
+from typing import Any, Dict, Optional, Tuple
+
+import docx
+import fitz  # PyMuPDF
+
+
+def analyser_docx(file_stream) -> Tuple[str, Optional[Dict[str, Any]]]:
+    """Tente d'extraire le texte et un template de style simplifié d'un DOCX.
+
+    Retourne ``(texte_brut, styles)`` où ``styles`` est ``None`` si l'extraction
+    de style échoue.
+    """
+    try:
+        file_stream.seek(0)
+        document = docx.Document(file_stream)
+        full_text = "\n".join(para.text for para in document.paragraphs)
+
+        styles: Optional[Dict[str, Any]] = None
+        try:
+            first_para = document.paragraphs[0] if document.paragraphs else None
+            first_run = first_para.runs[0] if first_para and first_para.runs else None
+            if first_run:
+                font_name = first_run.font.name or "Calibri"
+                font_size = first_run.font.size.pt if first_run.font.size else 11
+                styles = {
+                    "prompt": {
+                        "font_name": font_name,
+                        "font_size": font_size,
+                        "is_bold": bool(first_run.bold),
+                    },
+                    "response": {
+                        "font_name": font_name,
+                        "font_size": font_size,
+                        "is_bold": False,
+                    },
+                }
+        except Exception:
+            styles = None
+
+        return full_text, styles
+    except Exception:
+        try:
+            file_stream.seek(0)
+            document = docx.Document(file_stream)
+            full_text = "\n".join(para.text for para in document.paragraphs)
+        except Exception:
+            full_text = ""
+        return full_text, None
+
+
+def analyser_pdf(file_stream) -> Tuple[str, None]:
+    """Extrait le contenu textuel brut d'un PDF."""
+    file_stream.seek(0)
+    with fitz.open(stream=file_stream.read(), filetype="pdf") as doc:
+        full_text = "".join(page.get_text() for page in doc)
+    return full_text, None
+
+
+def analyser_document(fichier) -> Tuple[str, Optional[Dict[str, Any]]]:
+    """Analyse un fichier importé et choisit la méthode appropriée."""
+    filename = fichier.name.lower()
+    if filename.endswith(".docx"):
+        return analyser_docx(fichier)
+    if filename.endswith(".pdf"):
+        return analyser_pdf(fichier)
+    return "", None

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ python-docx
 markdown
 beautifulsoup4
 lxml
+PyMuPDF


### PR DESCRIPTION
## Summary
- add document importer to extract text and styles from DOCX or PDF
- wire Streamlit UI to accept uploads and forward style template to exporter
- allow DOCX exporter to use source template with fallback to UI styles
- include PyMuPDF dependency for PDF parsing

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_68ad903d5aa0832b8aa3dd099117fa3c